### PR TITLE
deps: updates wazero to 1.0.1

### DIFF
--- a/wazero-step-by-step/01-wasi-simple-function/go.mod
+++ b/wazero-step-by-step/01-wasi-simple-function/go.mod
@@ -2,4 +2,4 @@ module github.com/wasm-university/wazero-step-by-step/01-wasi-simple-function/ma
 
 go 1.18
 
-require github.com/tetratelabs/wazero v1.0.0-pre.4
+require github.com/tetratelabs/wazero v1.0.1

--- a/wazero-step-by-step/01-wasi-simple-function/go.sum
+++ b/wazero-step-by-step/01-wasi-simple-function/go.sum
@@ -1,2 +1,2 @@
-github.com/tetratelabs/wazero v1.0.0-pre.4 h1:RBJQT5OzmORkSp6MmZDWoFEr0zXjk4pmvMKAdeUnsaI=
-github.com/tetratelabs/wazero v1.0.0-pre.4/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
+github.com/tetratelabs/wazero v1.0.1 h1:xyWBoGyMjYekG3mEQ/W7xm9E05S89kJ/at696d/9yuc=
+github.com/tetratelabs/wazero v1.0.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=

--- a/wazero-step-by-step/01-wasi-simple-function/main.go
+++ b/wazero-step-by-step/01-wasi-simple-function/main.go
@@ -30,7 +30,7 @@ func main() {
 		log.Panicln(err)
 	}
 
-	mod, err := r.InstantiateModuleFromBinary(ctx, helloWasm)
+	mod, err := r.Instantiate(ctx, helloWasm)
 	if err != nil {
 		log.Panicln(err)
 	}

--- a/wazero-step-by-step/02-wasi-host-function/go.mod
+++ b/wazero-step-by-step/02-wasi-host-function/go.mod
@@ -2,4 +2,4 @@ module github.com/wasm-university/wazero-step-by-step/02-wasi-host-function/main
 
 go 1.18
 
-require github.com/tetratelabs/wazero v1.0.0-pre.4
+require github.com/tetratelabs/wazero v1.0.1

--- a/wazero-step-by-step/02-wasi-host-function/go.sum
+++ b/wazero-step-by-step/02-wasi-host-function/go.sum
@@ -1,2 +1,2 @@
-github.com/tetratelabs/wazero v1.0.0-pre.4 h1:RBJQT5OzmORkSp6MmZDWoFEr0zXjk4pmvMKAdeUnsaI=
-github.com/tetratelabs/wazero v1.0.0-pre.4/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
+github.com/tetratelabs/wazero v1.0.1 h1:xyWBoGyMjYekG3mEQ/W7xm9E05S89kJ/at696d/9yuc=
+github.com/tetratelabs/wazero v1.0.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=

--- a/wazero-step-by-step/02-wasi-host-function/main.go
+++ b/wazero-step-by-step/02-wasi-host-function/main.go
@@ -28,7 +28,7 @@ func main() {
 			fmt.Println("🤖:", value)
 		}).
 		Export("hostLogUint32").
-		Instantiate(ctx, r)
+		Instantiate(ctx)
 
 	if errEnv != nil {
 		log.Panicln(errEnv)
@@ -45,7 +45,7 @@ func main() {
 		log.Panicln(err)
 	}
 
-	mod, err := r.InstantiateModuleFromBinary(ctx, helloWasm)
+	mod, err := r.Instantiate(ctx, helloWasm)
 	if err != nil {
 		log.Panicln(err)
 	}

--- a/wazero-step-by-step/03-wasi-host-function/go.mod
+++ b/wazero-step-by-step/03-wasi-host-function/go.mod
@@ -2,4 +2,4 @@ module github.com/wasm-university/wazero-step-by-step/03-wasi-host-function/main
 
 go 1.18
 
-require github.com/tetratelabs/wazero v1.0.0-pre.4
+require github.com/tetratelabs/wazero v1.0.1

--- a/wazero-step-by-step/03-wasi-host-function/go.sum
+++ b/wazero-step-by-step/03-wasi-host-function/go.sum
@@ -1,2 +1,2 @@
-github.com/tetratelabs/wazero v1.0.0-pre.4 h1:RBJQT5OzmORkSp6MmZDWoFEr0zXjk4pmvMKAdeUnsaI=
-github.com/tetratelabs/wazero v1.0.0-pre.4/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
+github.com/tetratelabs/wazero v1.0.1 h1:xyWBoGyMjYekG3mEQ/W7xm9E05S89kJ/at696d/9yuc=
+github.com/tetratelabs/wazero v1.0.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=

--- a/wazero-step-by-step/03-wasi-host-function/main.go
+++ b/wazero-step-by-step/03-wasi-host-function/main.go
@@ -22,7 +22,7 @@ func main() {
 	_, errEnv := r.NewHostModuleBuilder("env").
 		NewFunctionBuilder().WithFunc(logUint32).Export("hostLogUint32").
 		NewFunctionBuilder().WithFunc(logString).Export("hostLogString").
-		Instantiate(ctx, r)
+		Instantiate(ctx)
 
 	if errEnv != nil {
 		log.Panicln("🔴 Error with env module and host function(s):", errEnv)
@@ -39,7 +39,7 @@ func main() {
 		log.Panicln("🔴 Error while loading the wasm module", errLoadWasmModule)
 	}
 
-	mod, errInstanceWasmModule := r.InstantiateModuleFromBinary(ctx, helloWasm)
+	mod, errInstanceWasmModule := r.Instantiate(ctx, helloWasm)
 	if errInstanceWasmModule != nil {
 		log.Panicln("🔴 Error while creating module instance ", errInstanceWasmModule)
 	}
@@ -63,7 +63,7 @@ func logUint32(value uint32) {
 }
 
 func logString(ctx context.Context, module api.Module, offset, byteCount uint32) {
-	buf, ok := module.Memory().Read(ctx, offset, byteCount)
+	buf, ok := module.Memory().Read(offset, byteCount)
 	if !ok {
 		log.Panicf("🟥 Memory.Read(%d, %d) out of range", offset, byteCount)
 	}


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.1](https://github.com/tetratelabs/wazero/releases/tag/v1.0.1).

On behalf of everyone in the community, I want to thank you for trying wazero before we became stable. We will not raise unsolicited pull requests anymore. That said, if any update gives you problems, please feel free to contact [us](https://wazero.io/community/) on slack or via a GitHub issue.

This PR also includes changes for [wazero](https://wazero.io/) [1.0.0-rc.2][0], [1.0.0-pre.9][1],
[wazero](https://wazero.io/) [1.0.0-pre.8][2]. Notably:

* Requires at least Go 1.8
* Renames `Runtime.InstantiateModuleFromBinary` to `Runtime.Instantiate`
* This release also integrates Go context to limit execution time.
  More details on the [Release Notes][1]
* Changes the `Instantiate` signature, which no longer requires
  an explicit `Runtime` instance.
* Changes the `Memory` `Read`/`Write` signatures, which no longer
  take a `Context`
* Full support to the WASI test suite and other third-party integration tests
* A number of optimizations to reduce compilation overhead


Finally, if you would like to share your work, feel free to update our [users page](https://github.com/tetratelabs/wazero/blob/main/site/content/community/users.md)!

[0]: https://github.com/tetratelabs/wazero/releases/tag/1.0.0-rc.2
[1]: https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.9
[2]: https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.8

Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>
